### PR TITLE
Fix data structure if return value of toArray function is a map data

### DIFF
--- a/lib/_utils.js
+++ b/lib/_utils.js
@@ -22,7 +22,7 @@ export function getGlobalObject() {
  */
 export function toArray(v, callback, _this) {
   const _callback = bindToFunction(callback, _this, function(v, k) {
-    return { k, v };
+    return { [k]: v };
   });
 
   const arr = [];


### PR DESCRIPTION
# 관련 이슈

https://github.com/mohwa/array-organizer/issues/8

# 작업 내용

- [x] 기존 `{  k: 'z', v: 33 }` 형태를 `{ z: 33 }` 형태로 수정합니다.

- [x] `array-organizer` 를 의존하는 다른 프로젝트에도(`object-organizer` 등 ...), 이 내용을 반영합니다.

- toArray 함수의 반환값(`[{ k, v }]`) 구조가 달라질 경우, 이 패키지를 의존하고있는 다른 패키지들의 내용(`의존중인 코드`, `사용 방법`, `관련 예제`)이 수정되어야할듯합니다.

> toArray 함수의 반환값([...])에서, `{ k, v }` 속성에 접근하지않을 경우, 관련 Side Effect 은 발생하지않습니다.

> toArray callback 함수에서, 전달받은 `k`, `v` 변수만 사용할 경우, 관련 Side Effect 은 발생하지않습니다.

- [ ] 이 경우, 반환되는 `데이터 구조`가 변경되는 부분이기에, [semver](https://semver.org/) 규칙에 따라 Major 버전을 업데이트해야할듯한데요, 의견 부탁드립니다.

@seongdohee , @prorice , @eunjeongsong 

- [ ] README 파일 예제 수정

#  emnida 체크 결과

getSize 함수는, toArray 반환값의 `length` 속성만 사용합니다.

```javascript
export function getSize(v) {
  switch (true) {
    case !isEmpty(v?.length):
      return v.length;
    default: {
      return toArray(v)?.length || 0;
    }
  }
}
```

https://github.com/mohwa/emnida/blob/511ca933393987d6f195d2fa8ad310fcc395d5af/lib/_utils.js#L17

`isEqualAtObject` 함수는, toArray callback 함수의 `k`, `v` 변수만 사용합니다.

또, `Set` 데이터인 경우, 수정된 `Map` 데이터 구조에 영향받지않습니다.

```javascript
export function isEqualAtObject(v, vv) {
...
        toArray(preV, (vv, k) => {
          // callback 을 통해 전달받은 k, v 값만 사용합니다.
          let _nextV = nextV[k];

          if (isMap(nextV)) {
            _nextV = nextV.get(k);
          }

          // Set 데이터인 경우,
          if (isSet(nextV)) {
            if (nextV.has(vv)) { 
              _nextV = toArray(nextV)[k];
            }
          }
          stacks.push({ preV: vv, nextV: _nextV });
        });
        break;
...
```

[https://github.com/mohwa/emnida/blob/511ca933393987d6f195d2fa8ad310fcc395d5af/lib/_utils.js#L53](https://github.com/mohwa/emnida/blob/511ca933393987d6f195d2fa8ad310fcc395d5af/lib/_utils.js#L53)

#  object-organizer 체크 결과

이 경우, 패키지 업데이트를 통해 해결됩니다.

```javascript
...
export { toArray };
...
```

https://github.com/mohwa/object-organizer/blob/2160e3d452014931f8cacd388fee594490818140/lib/index.js#L99

아래 함수는, toArray callback 함수의 `k`, `v` 변수만 사용합니다.

```javascript
...
        toArray(v, (vv, kk) => {
          stacks.push({ container: newContainer, k: kk, v: vv });
        });
...
```

https://github.com/mohwa/object-organizer/blob/9a40cbb0f3a2357becdde90d633b8955164ee90d/lib/_utils.js#L73

https://github.com/mohwa/object-organizer/blob/9a40cbb0f3a2357becdde90d633b8955164ee90d/lib/_utils.js#L108

https://github.com/mohwa/object-organizer/blob/2160e3d452014931f8cacd388fee594490818140/lib/index.js#L165

https://github.com/mohwa/object-organizer/blob/2160e3d452014931f8cacd388fee594490818140/lib/index.js#L170

이 경우, 배열 데이터에만 해당됩니다.

```javascript
...
    case isArray(v) || isMap(v) || isSet(v): {
      switch (true) {
        case isMap(v): {
          const newMap = new Map();
          toArray(v, (v, k) => newMap.set(k, v));
          return newMap;
        }
        case isSet(v): {
          const newSet = new Set();
          toArray(v, v => newSet.add(v));
          return newSet;
        }
        default:
          return toArray(v);
      }
    }
...
```

https://github.com/mohwa/object-organizer/blob/2160e3d452014931f8cacd388fee594490818140/lib/index.js#L174
